### PR TITLE
https://addons.mozilla.org/firefox/addon/passff/ does not link android's

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ The host application allows the extension to communicate with `pass` on your sys
 
 ##### PassFF extension
 Install the current release of PassFF for your browser:
-  - [Firefox](https://addons.mozilla.org/firefox/addon/passff)
+  - [Firefox for desktop](https://addons.mozilla.org/firefox/addon/passff)
+  - [Firefox for Android](https://addons.mozilla.org/android/addon/passff/)
 
 Previous releases are available for download as XPI files from [our releases page](https://github.com/passff/passff/releases). However, this is strongly discouraged for security reasons!
 


### PR DESCRIPTION
The passff extension link works for desktops, but when trying to install it to Firefox for Android, it shows the message "ⓘTo find extensions compatible with Firefox for Android, [click here](https://addons.mozilla.org/en-US/android/)".

Entering "passff" in the searchbox of last link suggests, as of today, fourteen results starting by "Bitwarden Password Manager", "Show/hide passwords", "Save my Password", ... and none of them are https://addons.mozilla.org/android/addon/passff/ which google found out.

Before accepting this pull-request, please check that https://addons.mozilla.org/android/addon/passff/ , which has same authors and same reviews, and same user count (1776) as of today, is really from you.